### PR TITLE
add: support for textarea input type

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        node { label 'jenkinsworker00' }
+        node { label 'jenkins-node-label-1' }
     }
     
     environment {

--- a/app/deployments/templates/input_types.html
+++ b/app/deployments/templates/input_types.html
@@ -37,6 +37,11 @@
 			<input type="text" class="form-control" data-type="{{value.type}}" id="{{key}}" name="{{key}}" value="{{value.default}}" aria-describedby="help{{key}}" placeholder="{{value.placeholder}}" {% if value.required %}data-required=true required{%endif%} {{mode}} />
 		<!-- end text type -->
 
+		<!-- textarea type -->
+		{% elif value.type == "textarea" %}
+			<textarea class="form-control" {% if value.rows %}rows="{{value.rows}}"{%endif%} data-type="text" id="{{key}}" name="{{key}}" aria-describedby="help{{key}}" placeholder="{{value.placeholder}}" {% if value.required %}data-required=true required{%endif%} {{mode}}>{{value.default}}</textarea>
+		<!-- end textarea type -->
+
 		<!-- number types -->
 		{% elif value.type == "integer" %}
 			<input type="number" min="0" class="form-control" data-type="{{value.type}}" id="{{key}}" name="{{key}}" value="{{value.default}}" {{ value.function }} {{ value.function_params }} aria-describedby="help{{key}}" placeholder="{{value.placeholder}}" {% if value.required %}data-required=true required{%endif%} {{mode}} />

--- a/app/lib/dbhelpers.py
+++ b/app/lib/dbhelpers.py
@@ -139,7 +139,7 @@ def updatedeploymentsstatus(deployments, userid):
         # Older deployments saved as provider name both the provider name and the
         # region, but in the Fed-Reg they are separate details.
         if providername != "" and providername in ast.literal_eval(
-            app.config.get("PROVIDER_NAMES_TO_SPLIT", [])
+            app.config.get("PROVIDER_NAMES_TO_SPLIT", "[]")
         ):
             providername, region_name = providername.split("-")
             region_name = region_name.lower()


### PR DESCRIPTION
Added input type "textarea" required for the integration of [Kubernetes Cluster with InterLink Virtual Node](https://confluence.infn.it/spaces/INFNCLOUD/pages/501088296/Kubernetes+Cluster+with+InterLink+Virtual+Node).